### PR TITLE
Make logging in work.

### DIFF
--- a/puzzad/users_test.go
+++ b/puzzad/users_test.go
@@ -30,8 +30,8 @@ type FakeUserDatabase struct {
 	setPasswordHash  string
 	setPasswordError error
 
-	getAdminsUsers []*ent.User
-	getAdminsError error
+	getAdminResponse bool
+	getAdminsError   error
 
 	setAdminUser  *ent.User
 	setAdminError error
@@ -42,8 +42,8 @@ func (f *FakeUserDatabase) GetUser(_ context.Context, email string) (*ent.User, 
 	return f.getUserResponse, f.getUserError
 }
 
-func (f *FakeUserDatabase) GetAdmins(_ context.Context) ([]*ent.User, error) {
-	return f.getAdminsUsers, f.getAdminsError
+func (f *FakeUserDatabase) HasAdmins(_ context.Context) (bool, error) {
+	return f.getAdminResponse, f.getAdminsError
 }
 
 func (f *FakeUserDatabase) GeneratePasswordResetCode(_ context.Context, u *ent.User) (string, error) {
@@ -65,6 +65,14 @@ func (f *FakeUserDatabase) SetPassword(_ context.Context, u *ent.User, hash stri
 func (f *FakeUserDatabase) SetAdmin(_ context.Context, u *ent.User, admin bool) error {
 	u.Admin = admin
 	return f.setPasswordError
+}
+
+func (f *FakeUserDatabase) CreateUser(ctx context.Context, email, hash string) (*ent.User, error) {
+	panic("implement me")
+}
+
+func (f *FakeUserDatabase) SetStatus(ctx context.Context, u *ent.User, status user.Status) error {
+	panic("implement me")
 }
 
 type FakeUserMailer struct {
@@ -360,23 +368,4 @@ func TestUserManager_FinishPasswordReset_returnsTrueOnSuccess(t *testing.T) {
 
 	hashOk, _ := CheckHash("newpassword", db.setPasswordHash)
 	assert.True(t, hashOk, "password hash must match the given password")
-}
-
-func TestUserManager_GetAdmins_Error(t *testing.T) {
-	db := &FakeUserDatabase{
-		getAdminsUsers: []*ent.User{},
-		getAdminsError: fmt.Errorf("test error"),
-	}
-	_, err := db.GetAdmins(context.Background())
-	assert.True(t, err != nil)
-}
-
-func TestUserManager_GetAdmins_Admins(t *testing.T) {
-	db := &FakeUserDatabase{
-		getAdminsUsers: []*ent.User{{}},
-		getAdminsError: nil,
-	}
-	admins, err := db.GetAdmins(context.Background())
-	assert.True(t, len(admins) == 1)
-	assert.True(t, err == nil)
 }

--- a/web/resources/templates/login.gohtml
+++ b/web/resources/templates/login.gohtml
@@ -6,8 +6,8 @@
 <article>
     <p>If you don't already have an account, you will need to <a href="/register">register</a> before signing in.</p>
     <form hx-post="/login" hx-disable-element="#submit">
-        <label for="username">Email: </label><input type="email" id="username" name="username" placeholder="user@domain.tld" required>
-        <label for="password">Password: </label><input type="text" id="password" name="password" required>
+        <label for="username">Email: </label><input type="email" id="username" name="username" placeholder="user@example.com" required>
+        <label for="password">Password: </label><input type="password" id="password" name="password" required>
         <button id="submit" type="submit">Login</button>
     </form>
     <p>If you've forgotten your password, click <a href="/passreset">here</a> to start the reset process.</p>


### PR DESCRIPTION
- Process form data instead of JSON, this is how HTMX works by
  default (and seems a lot easier to work with)
- Actually validate account details when logging in(!)
- Move the admin creation logic into the UserManager, and make
  it mark admin accounts as valid by default
- Instead of returning all admins that exist then counting them,
  simply check if there is one in the database
- Make the password field a password field :D

Still to do:
- Tests for new UserManager methods
- Errors returned by the login endpoint aren't shown by HTMX
